### PR TITLE
add support for avrtiny devices

### DIFF
--- a/debugSerial.h
+++ b/debugSerial.h
@@ -23,6 +23,7 @@
 #define bit(io)     BIT(io)
 #define port(io)    PORT(io)
 
+
 extern "C" void write_r20();
 
 // transmit character in r20, clobbers __tmp_reg__, leaves T set

--- a/debugSerial.h
+++ b/debugSerial.h
@@ -23,19 +23,13 @@
 #define bit(io)     BIT(io)
 #define port(io)    PORT(io)
 
-#if defined(__AVR_TINY__)
-#define TX_REG "r25"
-#else
-#define TX_REG "r18"
-#endif
+extern "C" void write_r20();
 
-extern "C" void write_r18();
-
-// transmit character in r18 (r25 on avrtiny), clobbers __tmp_reg__, leaves T set
+// transmit character in r20, clobbers __tmp_reg__, leaves T set
 __attribute((weak, naked))
-void write_r18()
+void write_r20()
 {
-    register char c asm(TX_REG);
+    register char c asm("r20");
     asm volatile (
     "cbi %[tx_port], %[tx_bit]\n"       // disable pullup
     "cli\n"
@@ -66,8 +60,8 @@ void write_r18()
 
 inline void dwrite(char ch)
 {
-    register char c asm(TX_REG) = ch;
-    asm volatile ("%~call %x1" : "+r"(c) : "i"(write_r18));
+    register char c asm("r20") = ch;
+    asm volatile ("%~call %x1" : "+r"(c) : "i"(write_r20));
 }
 
 
@@ -79,33 +73,33 @@ inline void dprints_p(const __FlashStringHelper* s)
     "%~call %x1"
     : "+z" (s)
     : "i" (printsp_z)
-    : TX_REG
+    : "r20"
     );
 }
 
 
-// asm function in print.S - print u8(r18) base16 (HEX)
-extern "C" void printu8b16_r18();
+// asm function in print.S - print u8(r20) base16 (HEX)
+extern "C" void printu8b16_r20();
 inline void dprintu8b16(uint8_t val)
 {
-    register char c asm(TX_REG) = val;
+    register char c asm("r20") = val;
     asm volatile (
     "%~call %x1"
     : "+r" (c) 
-    : "i" (printu8b16_r18)
+    : "i" (printu8b16_r20)
     );
 }
 
-// asm function in print.S - print u16(r21:20) base10 (DEC)
-extern "C" void printu16b10_r20();
+// asm function in print.S - print u16(r23:22) base10 (DEC)
+extern "C" void printu16b10_r22();
 inline void dprintu16b10(uint16_t val)
 {
-    register uint16_t i asm("r20") = val;
+    register uint16_t i asm("r22") = val;
     asm volatile (
     "%~call %x1"
     : "+r" (i) 
-    : "i" (printu16b10_r20)
-    : TX_REG
+    : "i" (printu16b10_r22)
+    : "r20"
     );
 }
 

--- a/print.S
+++ b/print.S
@@ -3,98 +3,91 @@
 ; uses external write_r18 function
 ; 20200414 - working versions of print for u8b10, u8b16, and flash strings
 
-#if defined(__AVR_TINY__)
-#define TX_REG r25
-#else
-#define TX_REG r18
-#endif
-
 .macro addi Rd, K
     subi \Rd, -(\K)
 .endm
 
 .section .text.printu16b10
 
-; print number in 21:20 as unsigned decimal (base 10): 31 instructions
+; print number in 22:21 as unsigned decimal (base 10): 31 instructions
 ; optimized from Peter Dannegger's version
-; clobbers r18 (r25 on avrtiny)
-.global printu16b10_r20
-printu16b10_r20:
+; clobbers r20
+.global printu16b10_r22
+printu16b10_r22:
     clt                                 ; T set for non-zero digit
-    ldi TX_REG, -1 + '0'                ; ten-thousands
-1:  inc TX_REG
-    subi r20, lo8(10000)
-    sbci r21, hi8(10000)
+    ldi r20, -1 + '0'                   ; ten-thousands
+1:  inc r20
+    subi r22, lo8(10000)
+    sbci r23, hi8(10000)
     brcc 1b
     rcall skip_leading0
 
-    ldi TX_REG, 10 + '0'                ; thousands
-2:  dec TX_REG
-    subi r20, lo8(-1000)
-    sbci r21, hi8(-1000)
+    ldi r20, 10 + '0'                   ; thousands
+2:  dec r20
+    subi r22, lo8(-1000)
+    sbci r23, hi8(-1000)
     brcs 2b
     rcall skip_leading0
 
-    ldi TX_REG, -1 + '0'                ; hundreds
-3:  inc TX_REG
-    subi r20, lo8(100)
-    sbci r21, hi8(100)
+    ldi r20, -1 + '0'                   ; hundreds
+3:  inc r20
+    subi r22, lo8(100)
+    sbci r23, hi8(100)
     brcc 3b
     rcall skip_leading0
 
-    ldi TX_REG, 10 + '0'                ; tens
-4:  dec TX_REG
-    addi r20, 10
+    ldi r20, 10 + '0'                   ; tens
+4:  dec r20
+    addi r22, 10
     brcs 4b
     rcall skip_leading0
 
-    addi r20, '0'                       ; ones
-    mov TX_REG, r20
+    addi r22, '0'                       ; ones
+    mov r20, r22
 putc:
-    rjmp write_r18
+    rjmp write_r20
 
 skip_leading0:
     brts putc
-    cpi TX_REG, '0'
-    brne putc                           ; write_r18 leaves T set
+    cpi r20, '0'
+    brne putc                           ; write_r20 leaves T set
     ret
 
 
 .section .text.printu8b16
 
-; print number in r18 (r25 on avrtiny) as unsigned hex (base 16): 10 instructions
-.global printu8b16_r18
-printu8b16_r18:
-    push TX_REG
-    swap TX_REG
+; print number in r20 as unsigned hex (base 16): 10 instructions
+.global printu8b16_r20
+printu8b16_r20:
+    push r20
+    swap r20
     rcall nibbletohex                   ; convert hi digit
-    pop TX_REG
+    pop r20
     ; fall into nibbletohex to convert lo digit
 nibbletohex:
-    andi TX_REG, 0x0F
-    cpi TX_REG, 10
+    andi r20, 0x0F
+    cpi r20, 10
     brlo 1f 
-    addi TX_REG, 'A'-':'
+    addi r20, 'A'-':'
 1:  ; less than 10
-    addi TX_REG, '0'
-    rjmp write_r18
+    addi r20, '0'
+    rjmp write_r20
 
 
 .section .text.printsp
 
 ; print null-terminated string in progmem, pointer in Z: 5 instructions
-; clobbers r18 (r25 on avrtiny) & Z
+; clobbers r20 & Z
 .global printsp_z
 printsp_z_write:
-    rcall write_r18
+    rcall write_r20
 printsp_z:
 #if defined(__AVR_TINY__)
-    ld TX_REG, Z+                       ; read next char
+    ld r20, Z+                          ; read next char
 #else
-    lpm TX_REG, Z+                      ; read next char
-#define TX_REG r18
+    lpm r20, Z+                         ; read next char
 #endif
-    tst TX_REG
+    tst r20
     brne printsp_z_write
     ret
 

--- a/print.S
+++ b/print.S
@@ -9,7 +9,7 @@
 
 .section .text.printu16b10
 
-; print number in 22:21 as unsigned decimal (base 10): 31 instructions
+; print number in 23:22 as unsigned decimal (base 10): 31 instructions
 ; optimized from Peter Dannegger's version
 ; clobbers r20
 .global printu16b10_r22

--- a/print.S
+++ b/print.S
@@ -3,6 +3,12 @@
 ; uses external write_r18 function
 ; 20200414 - working versions of print for u8b10, u8b16, and flash strings
 
+#if defined(__AVR_TINY__)
+#define TX_REG r25
+#else
+#define TX_REG r18
+#endif
+
 .macro addi Rd, K
     subi \Rd, -(\K)
 .endm
@@ -11,79 +17,84 @@
 
 ; print number in 21:20 as unsigned decimal (base 10): 31 instructions
 ; optimized from Peter Dannegger's version
-; clobbers r18
+; clobbers r18 (r25 on avrtiny)
 .global printu16b10_r20
 printu16b10_r20:
     clt                                 ; T set for non-zero digit
-    ldi r18, -1 + '0'                   ; ten-thousands
-1:  inc r18
+    ldi TX_REG, -1 + '0'                ; ten-thousands
+1:  inc TX_REG
     subi r20, lo8(10000)
     sbci r21, hi8(10000)
     brcc 1b
     rcall skip_leading0
 
-    ldi r18, 10 + '0'                   ; thousands
-2:  dec r18
+    ldi TX_REG, 10 + '0'                ; thousands
+2:  dec TX_REG
     subi r20, lo8(-1000)
     sbci r21, hi8(-1000)
     brcs 2b
     rcall skip_leading0
 
-    ldi r18, -1 + '0'                   ; hundreds
-3:  inc r18
+    ldi TX_REG, -1 + '0'                ; hundreds
+3:  inc TX_REG
     subi r20, lo8(100)
     sbci r21, hi8(100)
     brcc 3b
     rcall skip_leading0
 
-    ldi r18, 10 + '0'                   ; tens
-4:  dec r18
+    ldi TX_REG, 10 + '0'                ; tens
+4:  dec TX_REG
     addi r20, 10
     brcs 4b
     rcall skip_leading0
 
     addi r20, '0'                       ; ones
-    mov r18, r20
+    mov TX_REG, r20
 putc:
     rjmp write_r18
 
 skip_leading0:
     brts putc
-    cpi r18, '0'
+    cpi TX_REG, '0'
     brne putc                           ; write_r18 leaves T set
     ret
 
 
 .section .text.printu8b16
 
-; print number in r18 as unsigned hex (base 16): 10 instructions
+; print number in r18 (r25 on avrtiny) as unsigned hex (base 16): 10 instructions
 .global printu8b16_r18
 printu8b16_r18:
-    push r18
-    swap r18
+    push TX_REG
+    swap TX_REG
     rcall nibbletohex                   ; convert hi digit
-    pop r18
+    pop TX_REG
     ; fall into nibbletohex to convert lo digit
 nibbletohex:
-    andi r18, 0x0F
-    cpi r18, 10
+    andi TX_REG, 0x0F
+    cpi TX_REG, 10
     brlo 1f 
-    addi r18, 'A'-':'
+    addi TX_REG, 'A'-':'
 1:  ; less than 10
-    addi r18, '0'
+    addi TX_REG, '0'
     rjmp write_r18
 
 
 .section .text.printsp
 
 ; print null-terminated string in progmem, pointer in Z: 5 instructions
-; clobbers r18 & Z
+; clobbers r18 (r25 on avrtiny) & Z
 .global printsp_z
 printsp_z_write:
     rcall write_r18
 printsp_z:
-    lpm r18, Z+                         ; read next char
-    tst r18
+#if defined(__AVR_TINY__)
+    ld TX_REG, Z+                       ; read next char
+#else
+    lpm TX_REG, Z+                      ; read next char
+#define TX_REG r18
+#endif
+    tst TX_REG
     brne printsp_z_write
     ret
 


### PR DESCRIPTION
I was looking for something exactly like this library for an attiny10. It's perfect! Only had to make a few small changes to make it work with a "reduced tiny" core:
- use `__tmp_reg__` (alias for r0, but r16 on avrtiny)
- use r25 instead of r18 on avrtiny
- avrtiny has no `lpm`, but can simply be replaced by `ld`